### PR TITLE
Look for specific components when searching for UI elements

### DIFF
--- a/Scribble/BrushBehaviour.cs
+++ b/Scribble/BrushBehaviour.cs
@@ -238,8 +238,7 @@ namespace Scribble
 
         private bool CheckForUI()
         {
-            var pointerData = PointerEventDataAcc(ref _pointer);
-            if (!(pointerData.pointerCurrentRaycast.gameObject is { } go)) return false;
+            if (!(_pointer._currentPointerData?.pointerCurrentRaycast.gameObject is { } go)) return false;
             return go.GetComponent<UIBehaviour>() is { };
         }
 
@@ -254,9 +253,6 @@ namespace Scribble
         {
             container.BindFactory<GameObject, BrushBehaviour, Factory>().FromFactory<CustomFactory>();
         }
-
-        private static readonly FieldAccessor<VRPointer, PointerEventData>.Accessor PointerEventDataAcc
-            = FieldAccessor<VRPointer, PointerEventData>.GetAccessor("_currentPointerData");
 
         internal class Factory : PlaceholderFactory<GameObject, BrushBehaviour>{}
 

--- a/Scribble/Scribble.csproj
+++ b/Scribble/Scribble.csproj
@@ -136,7 +136,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(BeatSaberDir)/Beat Saber_Data/Managed/UnityEngine.XRModule.dll</HintPath>
     </Reference>
-    <Reference Include="VRUI, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="VRUI, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL" Publicize="true">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(BeatSaberDir)/Beat Saber_Data/Managed/VRUI.dll</HintPath>
     </Reference>

--- a/Scribble/UI/UITools.cs
+++ b/Scribble/UI/UITools.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using HMUI;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -46,27 +47,27 @@ namespace Scribble
             return imageComp;
         }
 
-        public static GameObject CreateFromInstance(this Transform parent, string name, bool worldPositionStays = false)
+        public static GameObject CreateFromInstance<T>(this Transform parent, string name, bool worldPositionStays = false) where T : Component
         {
-            GameObject go = Resources.FindObjectsOfTypeAll<GameObject>().FirstOrDefault(g => g.name == name);
+            GameObject go = Object.FindObjectsOfType<T>(true).First(g => g.name == name).gameObject;
             return Object.Instantiate(go, parent, worldPositionStays);
         }
 
         public static ScribbleUISlider CreateSlider(this Transform parent)
         {
-            GameObject go = parent.CreateFromInstance("PositionX");
+            GameObject go = parent.CreateFromInstance<RangeValuesTextSlider>("PositionX");
             return new ScribbleUISlider(go);
         }
 
         public static ScribbleUISimpleButton CreateSimpleButton(this Transform parent, string text, ButtonColors? buttonColors = null)
         {
-            GameObject go = parent.CreateFromInstance("ApplyButton");
+            GameObject go = parent.CreateFromInstance<NoTransitionsButton>("ApplyButton");
             return new ScribbleUISimpleButton(go, text, buttonColors);
         }
 
         public static ScribbleUICheckbox CreateCheckbox(this Transform parent)
         {
-            GameObject go = parent.CreateFromInstance("Toggle");
+            GameObject go = parent.CreateFromInstance<Toggle>("Toggle");
             return new ScribbleUICheckbox(go);
         }
 


### PR DESCRIPTION
This prevents objects with the same name created by other mods from being accidentally grabbed. Kind of a lazy fix, but it works!